### PR TITLE
Adding server-side support for Unicode primes

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,7 +14,7 @@ dayjs.extend(weekOfYear)
 dayjs.extend(weekYear)
 
 export function replaceQuote(string: string): string {
-  return string.replace(/[‘’`]/g, "'")
+  return string.replace(/[‘’`′]/g, "'")
 }
 
 export function removeComment(string: string | string[]): string {


### PR DESCRIPTION
I submitted a pull request (to the 333.fm repo) months ago that added support for Unicode prime symbols to the client-side code. I didn’t realize the server-side code was in a separate repo nor that this repo had the same `replaceQuote` function as the client-side logic. This change brings the server-side code into alignment with the client-side code so that Unicode prime symbols are treated the same as straight and curly quotes.